### PR TITLE
Added backend support for filtering by categories

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -105,7 +105,7 @@ def filtering_years(query_results, filter_years):
 
 def preprocess_query_params(query_params):
     query_params['query'] = query_params.get('query', '')
-    for param in ['movie_title', 'actor', 'keywords', 'year']:
+    for param in ['movie_title', 'actor', 'keywords', 'year', 'categories']:
         query_params[param] = query_params.get(param, '')  # setting missing params to default empty strings
 
     query = query_params['query']

--- a/api/static/swagger.json
+++ b/api/static/swagger.json
@@ -18,24 +18,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "query": {
-                      "type": "string"
-                    },
-                    "movie_title": {
-                      "type": "string"
-                    },
-                    "actor": {
-                      "type": "string"
-                    },
-                    "keywords": {
-                      "type": "string"
-                    },
-                    "year": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/query_params"
                 }
               }
             }
@@ -67,24 +50,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "query": {
-                      "type": "string"
-                    },
-                    "movie_title": {
-                      "type": "string"
-                    },
-                    "actor": {
-                      "type": "string"
-                    },
-                    "keywords": {
-                      "type": "string"
-                    },
-                    "year": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/query_params"
                 }
               }
             }
@@ -106,6 +72,29 @@
   },
   "components": {
     "schemas": {
+      "query_params": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string"
+          },
+          "movie_title": {
+            "type": "string"
+          },
+          "categories": {
+            "type": "string"
+          },
+          "actor": {
+            "type": "string"
+          },
+          "keywords": {
+            "type": "string"
+          },
+          "year": {
+            "type": "string"
+          }
+        }
+      },
       "movie": {
         "type": "object",
         "properties": {

--- a/db/MongoDB.py
+++ b/db/MongoDB.py
@@ -114,8 +114,14 @@ class MongoDB(DBInterface):
                 year = re.split('-', query_params['year'])
                 and_list.append({"year": {"$gte": int(year[0]), "$lte": int(year[1])}})
             except:
-                pass
+                print(f"Attempted to make advanced search with invalid year: {query_params['year']}")
         if query_params.get('actor', False):
             and_list.append({"cast.actor": query_params['actor']})
+        if query_params.get('categories', False):
+            try:
+                categories = re.split(',', query_params['categories'])
+                and_list.append({'categories': {'$in': categories}})
+            except:
+                print(f"Attempted to make advanced search with invalid categories: {query_params['categories']}")
         movies = self.movies.find({"$and": and_list}, {"_id": 1})
         return set(map(itemgetter('_id'), movies))

--- a/ir_eval/ranking/main.py
+++ b/ir_eval/ranking/main.py
@@ -70,7 +70,7 @@ def ranking_query_BM25(query_params, batch_size=MAX_INDEX_SPLITS):
     terms = query_params['query']
     # Prepare advanced search if any filters are provided
     filtered_movies = None
-    if len(query_params['movie_title']) > 0 or len(query_params['year']) > 0 or len(query_params['actor']) > 0:
+    if any(len(query_params.get(param, '')) > 0 for param in ['movie_title', 'year', 'actor', 'categories']):
         print('advanced search')
         filtered_movies = db.get_movie_ids_advanced_search(query_params)
 

--- a/ir_eval/ranking/movie_search.py
+++ b/ir_eval/ranking/movie_search.py
@@ -70,7 +70,7 @@ def movie_ranking_query_TFIDF(query_params):
     terms = query_params['query']
     # Prepare advanced search if any filters are provided
     filtered_movies = None
-    if len(query_params['movie_title']) > 0 or len(query_params['year']) > 0 or len(query_params['actor']) > 0:
+    if any(len(query_params.get(param, '')) > 0 for param in ['movie_title', 'year', 'actor', 'categories']):
         print('advanced search')
         filtered_movies = db.get_movie_ids_advanced_search(query_params)
 

--- a/ir_eval/ranking/phrase_search.py
+++ b/ir_eval/ranking/phrase_search.py
@@ -33,7 +33,7 @@ def query_phrase_search(query_params):
     terms = query_params['query']
     # Prepare advanced search if any filters are provided
     filtered_movies = None
-    if len(query_params['movie_title']) > 0 or len(query_params['year']) > 0 or len(query_params['actor']) > 0:
+    if any(len(query_params.get(param, '')) > 0 for param in ['movie_title', 'year', 'actor', 'categories']):
         print('advanced search')
         filtered_movies = db.get_movie_ids_advanced_search(query_params)
 

--- a/tests/test_movie_search.py
+++ b/tests/test_movie_search.py
@@ -20,5 +20,14 @@ class TestMovieSearch(unittest.TestCase):
         print("Advanced match {:.4f} s".format(end-start))
         self.assertEqual("tt0080684", results[0])  # Star Wars V should definitely be Top 1 result in year 1980
 
+    def test_movie_search_advanced_categories(self):
+        query_params = {'query': ['luke', 'father'], 'categories': 'History,Biography'}
+        start = time.time()
+        results = ranked_movie_search(query_params, 100)
+        end = time.time()
+        print("Advanced categories match {:.4f} s".format(end - start))
+        self.assertNotIn("tt0080684", results)  # Star Wars V should not be among history movies
+        self.assertIn("tt0112573", results[:10])  # Braveheart, however, should be among top results
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added query param 'categories': string to /query_search and /movie_search endpoints. Advanced search now supports filtering by categories. Updated Swagger Docs to reflect the change. Refactored if statement triggering advanced search, now it is no longer necessary for query_params to have fields 'movie_title', 'year', 'actor' and 'categories' set compulsory. Added a unit test to make sure that categories filtering is working.